### PR TITLE
feat(#4): Enforce DefaultAzureCredential Across All Clients

### DIFF
--- a/src/utils/m_ai_client.py
+++ b/src/utils/m_ai_client.py
@@ -14,7 +14,7 @@ load_dotenv()
 _cached_aiproject_client: projects.AIProjectClient | None = None
 
 
-class AuthManager:
+class _AuthManager:
     """Manage Azure authentication.
 
     Uses DefaultAzureCredential which supports:
@@ -23,11 +23,17 @@ class AuthManager:
     - managed identity (when running in Azure)
     """
 
+    def __init__(self) -> None:
+        self._cached_credential: Any = None
+
     def get_azure_credential(self) -> Any:
-        """Return a DefaultAzureCredential instance.
+        """Return a DefaultAzureCredential instance (cached).
 
         Raises ClientAuthenticationError when credentials cannot be created.
         """
+        if self._cached_credential is not None:
+            return self._cached_credential
+
         try:
             # If the app is configured to *explicitly* use a service principal,
             # require the SP env vars to be present and non-empty. Otherwise,
@@ -51,6 +57,7 @@ class AuthManager:
 
             cred = DefaultAzureCredential()
             f_log("Created DefaultAzureCredential.", c_type="debug")
+            self._cached_credential = cred
             return cred
         except ClientAuthenticationError as e:
             f_log(f"Azure authentication failed: {e}", c_type="error")
@@ -69,8 +76,12 @@ class ClientManager:
     OpenAI-style client from `AIProjectClient.get_openai_client()`.
     """
 
-    def __init__(self, auth: AuthManager | None = None) -> None:
-        self.auth = auth or AuthManager()
+    def __init__(self) -> None:
+        self._auth = _AuthManager()
+
+    def get_credential(self) -> Any:
+        """Return the shared credential from the internal AuthManager."""
+        return self._auth.get_azure_credential()
 
     def get_aiproject_client(self) -> projects.AIProjectClient:
         """Return an authenticated `AIProjectClient` for Azure AI Foundry.
@@ -87,24 +98,28 @@ class ClientManager:
             return _cached_aiproject_client
 
         f_log("Initializing Azure credential for AIProjectClient.", c_type="process")
-        cred = self.auth.get_azure_credential()
+        cred = self.get_credential()
 
         try:
-            # Connection-string style
+            # Handle potential connection strings by extracting the endpoint
+            # In AIProjectClient 2.0.1, constructor expects `endpoint` as first arg.
+            clean_endpoint = endpoint
             if ";" in endpoint:
-                client = projects.AIProjectClient.from_connection_string(conn_str=endpoint)  # type: ignore
-            else:
-                clean = endpoint.replace("endpoint=", "").strip()
-                client = projects.AIProjectClient(endpoint=clean, credential=cred)
-
+                # Basic parsing: find endpoint=...
+                for part in endpoint.split(";"):
+                    if part.strip().startswith("endpoint="):
+                        clean_endpoint = part.split("=", 1)[1].strip()
+                        break
+            
+            clean_endpoint = clean_endpoint.replace("endpoint=", "").strip()
+            
+            client = projects.AIProjectClient(endpoint=clean_endpoint, credential=cred)
             _cached_aiproject_client = client
             f_log("AIProjectClient initialized.", c_type="success")
             return client
         except Exception as e:
             f_log(f"Failed to initialize AIProjectClient: {e}", c_type="error")
             raise
-
-    # Legacy chat completions client removed. Use `get_openai_client()` instead.
 
     def get_openai_client(self):
         """Return an OpenAI-style client from the AIProjectClient.
@@ -125,5 +140,3 @@ class ClientManager:
                 "— update SDK or use a different surface"
             )
         return get_client()
-
-

--- a/tests/test_credential_passthrough.py
+++ b/tests/test_credential_passthrough.py
@@ -1,0 +1,87 @@
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import src.utils.m_ai_client as m_ai_client
+from src.agents.architecture_composer import ArchitectureComposerAgent
+from src.agents.intake_reviewer import IntakeReviewerAgent
+from src.utils.m_ai_client import ClientManager
+
+
+@pytest.fixture(autouse=True)
+def reset_global_cache():
+    """Reset the global AIProjectClient cache between tests."""
+    m_ai_client._cached_aiproject_client = None
+    yield
+    m_ai_client._cached_aiproject_client = None
+
+def test_client_manager_single_credential_source():
+    """Verify that ClientManager uses a single credential source and passes it to clients."""
+    with patch("azure.identity.DefaultAzureCredential") as mock_cred_cls:
+        mock_cred_instance = MagicMock()
+        mock_cred_cls.return_value = mock_cred_instance
+        
+        cm = ClientManager()
+        
+        # First call to get_credential should create it
+        cred1 = cm.get_credential()
+        assert cred1 == mock_cred_instance
+        mock_cred_cls.assert_called_once()
+        
+        # Second call should return the same instance due to caching
+        cred2 = cm.get_credential()
+        assert cred2 == mock_cred_instance
+        mock_cred_cls.assert_called_once()
+
+def test_credential_passthrough_to_aiproject_client_endpoint(monkeypatch):
+    """Verify that the credential from ClientManager is passed to AIProjectClient (endpoint style)."""
+    monkeypatch.setenv("AZURE_AAIF_PROJECT_ENDPOINT", "endpoint=https://test.endpoint")
+    
+    with patch("src.utils.m_ai_client._AuthManager.get_azure_credential") as mock_get_cred:
+        mock_cred = MagicMock()
+        mock_get_cred.return_value = mock_cred
+        
+        # Patch AIProjectClient where it is USED in src.utils.m_ai_client
+        with patch("src.utils.m_ai_client.projects.AIProjectClient") as mock_ai_client_cls:
+            cm = ClientManager()
+            cm.get_aiproject_client()
+            
+            # Check if AIProjectClient was initialized with the credential
+            assert mock_ai_client_cls.called
+            args, kwargs = mock_ai_client_cls.call_args
+            assert kwargs["credential"] == mock_cred
+            assert kwargs["endpoint"] == "https://test.endpoint"
+
+def test_credential_passthrough_to_aiproject_client_conn_str(monkeypatch):
+    """Verify that the credential from ClientManager is passed to AIProjectClient (connection string style)."""
+    # Simulate a full connection string
+    monkeypatch.setenv("AZURE_AAIF_PROJECT_ENDPOINT", "location=eastus;endpoint=https://ai.example.com;project=foo")
+    
+    with patch("src.utils.m_ai_client._AuthManager.get_azure_credential") as mock_get_cred:
+        mock_cred = MagicMock()
+        mock_get_cred.return_value = mock_cred
+        
+        # Patch AIProjectClient where it is USED in src.utils.m_ai_client
+        with patch("src.utils.m_ai_client.projects.AIProjectClient") as mock_ai_client_cls:
+            cm = ClientManager()
+            cm.get_aiproject_client()
+            
+            # Check if AIProjectClient was initialized with the PARSED endpoint and credential
+            assert mock_ai_client_cls.called
+            args, kwargs = mock_ai_client_cls.call_args
+            assert kwargs["credential"] == mock_cred
+            assert kwargs["endpoint"] == "https://ai.example.com"
+
+def test_orchestrator_agent_credential_sharing():
+    """Verify that agents share the same ClientManager and thus the same credential instance."""
+    cm = ClientManager()
+    reviewer = IntakeReviewerAgent(client_manager=cm)
+    composer = ArchitectureComposerAgent(client_manager=cm)
+    
+    assert reviewer.client_manager == cm
+    assert composer.client_manager == cm
+    
+    cred1 = reviewer.client_manager.get_credential()
+    cred2 = composer.client_manager.get_credential()
+    assert cred1 == cred2


### PR DESCRIPTION
﻿## Summary
Automated implementation for issue #4.

## Changes
See commits for detailed changes. Implementation follows GEMINI.md project rules and .agents/skills/ coding standards.

## Validation
- `task test` — passed
- `task lint` — passed

## Linked Issue
Closes #4
