### PR TITLE
feat(#40): Approval gate and diagram trio persistence

### DIFF
--- a/src/agents/diagram_studio.py
+++ b/src/agents/diagram_studio.py
@@ -2,12 +2,14 @@ from __future__ import annotations
 
 import json
 import re
+import time
 from dataclasses import dataclass, field
 
 from src.agents._refinement import RefinementMixin
 from src.config import AGENT_MODELS
 from src.utils.m_diagram_engine import DiagramEngine
 from src.utils.m_log import f_log
+from src.utils.m_persist_design import ArchitecturePersister, _brief_to_markdown
 
 _D2_SYSTEM_PROMPT = (
     "You are a D2 diagram code generator. "
@@ -18,6 +20,8 @@ _D2_SYSTEM_PROMPT = (
 )
 
 _D2_PATTERN = re.compile(r"```d2\n(.*?)```", re.DOTALL)
+
+_APPROVAL_PHRASES = frozenset({"yes", "approved", "looks good", "lgtm", "ship it"})
 
 
 @dataclass
@@ -66,8 +70,46 @@ def _format_grill_questions(questions: list) -> str:
     return "\n".join(lines)
 
 
+def _is_approved(user_input: str) -> bool:
+    return user_input.strip().lower() in _APPROVAL_PHRASES
+
+
+def _derive_diagram_name(brief: dict) -> str:
+    subject = brief.get("subject", "").strip()
+    if not subject:
+        return f"diagram_{int(time.time())}"
+    safe = re.sub(r"[^a-zA-Z0-9 ]", "", subject).strip()
+    name = safe[:30].replace(" ", "_")
+    return name if name else f"diagram_{int(time.time())}"
+
+
+def _brief_dict_to_dataclass(brief: dict) -> DiagramBrief:
+    components = [
+        ComponentSpec(
+            name=c.get("name", ""),
+            shape=c.get("shape", "rectangle"),
+            group=c.get("group"),
+        )
+        for c in brief.get("components", [])
+    ]
+    relationships = [
+        RelationshipSpec(
+            from_component=r.get("from_component", ""),
+            to_component=r.get("to_component", ""),
+            label=r.get("label"),
+        )
+        for r in brief.get("relationships", [])
+    ]
+    return DiagramBrief(
+        subject=brief.get("subject", ""),
+        components=components,
+        relationships=relationships,
+        layout_direction=brief.get("layout_direction", "right"),
+    )
+
+
 class DiagramStudioModule(RefinementMixin):
-    """Diagram capability module: grill loop → DiagramBrief → D2 → sketch-rendered SVG."""
+    """Diagram capability module: grill loop → DiagramBrief → approval gate → D2 → sketch-rendered SVG."""
 
     name = "Diagram Studio"
     slash_command = "/diagram"
@@ -78,8 +120,11 @@ class DiagramStudioModule(RefinementMixin):
         self._client_manager = client_manager
 
     def handle(self, user_input: str, module_state: dict) -> ModuleResponse:
-        if module_state.get("phase") == "grilling":
+        phase = module_state.get("phase")
+        if phase == "grilling":
             return self._grill_turn(user_input, module_state)
+        if phase == "awaiting_approval":
+            return self._approval_turn(user_input, module_state)
         return self._first_turn(user_input, module_state)
 
     def _first_turn(self, user_input: str, module_state: dict) -> ModuleResponse:
@@ -89,7 +134,7 @@ class DiagramStudioModule(RefinementMixin):
         grill = self.grill_round(description, {})
         new_state = {"phase": "grilling", "description": description, "brief": grill.updated_brief}
         if grill.complete:
-            return self._generate_diagram(grill.updated_brief, new_state)
+            return self._present_for_approval(grill.updated_brief, new_state)
         return ModuleResponse(
             response_text=_format_grill_questions(grill.questions),
             updated_state=new_state,
@@ -104,15 +149,36 @@ class DiagramStudioModule(RefinementMixin):
         grill = self.grill_round(context, current_brief)
         new_state = {**module_state, "brief": grill.updated_brief}
         if grill.complete:
-            return self._generate_diagram(grill.updated_brief, new_state)
+            return self._present_for_approval(grill.updated_brief, new_state)
         return ModuleResponse(
             response_text=_format_grill_questions(grill.questions),
             updated_state={**new_state, "phase": "grilling"},
             status="in_refinement",
         )
 
+    def _present_for_approval(self, brief: dict, module_state: dict) -> ModuleResponse:
+        brief_obj = _brief_dict_to_dataclass(brief)
+        md = _brief_to_markdown(brief_obj)
+        response = (
+            "I've built up the following diagram brief:\n\n"
+            + md
+            + "\n\nReply `yes`, `approved`, `lgtm`, `looks good`, or `ship it` to generate the diagram, "
+            "or describe any changes."
+        )
+        return ModuleResponse(
+            response_text=response,
+            updated_state={**module_state, "phase": "awaiting_approval", "brief": brief},
+            status="awaiting_approval",
+        )
+
+    def _approval_turn(self, user_input: str, module_state: dict) -> ModuleResponse:
+        if _is_approved(user_input):
+            brief = module_state.get("brief", {})
+            return self._generate_diagram(brief, module_state)
+        return self._grill_turn(user_input, {**module_state, "phase": "grilling"})
+
     def _generate_diagram(self, brief: dict, module_state: dict) -> ModuleResponse:
-        f_log("DiagramStudioModule: generating D2 from completed brief.", level="process")
+        f_log("DiagramStudioModule: generating D2 from approved brief.", level="process")
         d2_code = self._generate_d2_from_brief(brief)
         if not d2_code:
             return ModuleResponse(
@@ -124,6 +190,10 @@ class DiagramStudioModule(RefinementMixin):
         artifacts: dict = {"d2": d2_code, "brief": brief}
         if svg_bytes:
             artifacts["svg"] = svg_bytes
+        brief_obj = _brief_dict_to_dataclass(brief)
+        name = _derive_diagram_name(brief)
+        persisted_path = ArchitecturePersister().persist_diagram(name, brief_obj, d2_code, svg_bytes or b"")
+        artifacts["persisted_path"] = str(persisted_path)
         return ModuleResponse(
             response_text=f"Here is the generated diagram:\n\n```d2\n{d2_code}\n```",
             updated_state={**module_state, "phase": "completed"},

--- a/src/utils/m_persist_design.py
+++ b/src/utils/m_persist_design.py
@@ -1,15 +1,51 @@
+from __future__ import annotations
+
 import os
 import time
+from pathlib import Path
+from typing import TYPE_CHECKING
 
 from src.config import DESIGNS_ARCHIVE_DIR
 from src.utils.m_log import f_log
 
+if TYPE_CHECKING:
+    from src.agents.diagram_studio import DiagramBrief
+
+
+def _brief_to_markdown(brief: DiagramBrief) -> str:
+    subject = getattr(brief, "subject", "") or "Diagram Brief"
+    lines = [
+        f"# {subject}",
+        "",
+        "## Metadata",
+        "",
+        "| Property | Value |",
+        "|----------|-------|",
+        f"| Subject | {subject} |",
+        f"| Layout Direction | {getattr(brief, 'layout_direction', 'right')} |",
+        f"| Sketch | {getattr(getattr(brief, 'style', None), 'sketch', True)} |",
+        "",
+        "## Components",
+        "",
+        "| Name | Shape | Group |",
+        "|------|-------|-------|",
+    ]
+    for c in getattr(brief, "components", []):
+        lines.append(f"| {c.name} | {c.shape} | {c.group or ''} |")
+    lines += [
+        "",
+        "## Relationships",
+        "",
+        "| From | To | Label |",
+        "|------|----|-------|",
+    ]
+    for r in getattr(brief, "relationships", []):
+        lines.append(f"| {r.from_component} | {r.to_component} | {r.label or ''} |")
+    return "\n".join(lines)
+
 
 class ArchitecturePersister:
-    """
-    Saves final documentation and SVGs into long-term history / approved repository directories.
-    Renamed to m_persist_design as requested for Single Responsibility clarity.
-    """
+    """Persists approved artefacts (architecture markdown, SVGs, diagram trios) to the designs/ directory."""
 
     def __init__(self, save_path: str = None) -> None:
         self.save_path = save_path or DESIGNS_ARCHIVE_DIR
@@ -17,10 +53,7 @@ class ArchitecturePersister:
             os.makedirs(self.save_path)
 
     def archive_solution(self, project_name: str, markdown_content: str, svg_bytes: bytes = None) -> str:
-        """
-        Dumps generated solution to filesystem with timestamp.
-        Returns the created directory path.
-        """
+        """Dumps generated solution to filesystem with timestamp. Returns the created directory path."""
         safe_name = "".join([c if c.isalnum() else "_" for c in project_name])
         timestamp = str(int(time.time()))
         project_dir = os.path.join(self.save_path, f"{safe_name}_{timestamp}")
@@ -28,14 +61,28 @@ class ArchitecturePersister:
         os.makedirs(project_dir, exist_ok=True)
         f_log(f"Archiving generated solution to {project_dir}", level="process")
 
-        # Save Markdown payload
         with open(os.path.join(project_dir, "architecture.md"), "w", encoding="utf-8") as f:
             f.write(markdown_content)
 
-        # Save SVG payload
         if svg_bytes:
             with open(os.path.join(project_dir, "diagram.svg"), "wb") as f:
                 f.write(svg_bytes)
 
         f_log("Archival sequence successful.", level="success")
         return project_dir
+
+    def persist_diagram(self, name: str, brief: DiagramBrief, d2_source: str, svg_bytes: bytes) -> Path:
+        """Writes brief.md, source.d2, and render.svg under diagrams/<name>_<timestamp>/. Re-raises on failure."""
+        timestamp = str(int(time.time()))
+        diagram_dir = Path(self.save_path) / "diagrams" / f"{name}_{timestamp}"
+        try:
+            diagram_dir.mkdir(parents=True, exist_ok=True)
+            f_log(f"Persisting diagram trio to {diagram_dir}", level="process")
+            (diagram_dir / "brief.md").write_text(_brief_to_markdown(brief), encoding="utf-8")
+            (diagram_dir / "source.d2").write_text(d2_source, encoding="utf-8")
+            (diagram_dir / "render.svg").write_bytes(svg_bytes)
+            f_log("Diagram trio persisted successfully.", level="success")
+        except Exception as e:
+            f_log(f"Diagram persistence failed: {e}", level="error")
+            raise
+        return diagram_dir

--- a/tests/agents/test_diagram_studio.py
+++ b/tests/agents/test_diagram_studio.py
@@ -1,4 +1,7 @@
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from src.agents._refinement import GrillQuestion, GrillRound
 from src.agents.diagram_studio import DiagramBrief, DiagramStudioModule, ModuleResponse
@@ -108,60 +111,38 @@ class TestFirstTurnGrillRound:
         assert captured["description"] == "medallion architecture"
 
 
-class TestRichDescriptionCompletedInFirstRound:
-    def test_rich_description_returns_completed(self):
-        module = _make_module()
-        with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg/>"
-                    result = module.handle("/diagram API connects to Database with a query", {})
-        assert result.status == "completed"
+class TestRichDescriptionAwaitingApproval:
+    """A fully-specified description on the first turn goes straight to awaiting_approval."""
 
-    def test_rich_description_has_d2_artifact(self):
+    def test_rich_description_returns_awaiting_approval(self):
         module = _make_module()
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg/>"
-                    result = module.handle("/diagram a detailed system", {})
-        assert "d2" in result.artifacts
-        assert result.artifacts["d2"] == "A -> B"
+            result = module.handle("/diagram API connects to Database with a query", {})
+        assert result.status == "awaiting_approval"
 
-    def test_rich_description_has_svg_artifact(self):
+    def test_brief_markdown_is_in_response(self):
         module = _make_module()
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg/>"
-                    result = module.handle("/diagram a detailed system", {})
-        assert "svg" in result.artifacts
-        assert result.artifacts["svg"] == b"<svg/>"
+            result = module.handle("/diagram a detailed system", {})
+        assert "API System" in result.response_text
 
-    def test_rich_description_no_svg_when_engine_fails(self):
+    def test_no_artifacts_at_approval_stage(self):
         module = _make_module()
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = None
-                    result = module.handle("/diagram a detailed system", {})
-        assert "svg" not in result.artifacts
+            result = module.handle("/diagram a detailed system", {})
+        assert result.artifacts == {}
 
-    def test_rich_description_error_when_d2_generation_fails(self):
+    def test_updated_state_has_awaiting_approval_phase(self):
         module = _make_module()
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value=None):
-                result = module.handle("/diagram a detailed system", {})
-        assert result.status == "error"
+            result = module.handle("/diagram a detailed system", {})
+        assert result.updated_state.get("phase") == "awaiting_approval"
 
-    def test_rich_description_includes_d2_in_response_text(self):
+    def test_brief_preserved_in_state(self):
         module = _make_module()
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="API -> Backend"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg/>"
-                    result = module.handle("/diagram detailed system", {})
-        assert "API -> Backend" in result.response_text
+            result = module.handle("/diagram a detailed system", {})
+        assert result.updated_state.get("brief", {}).get("subject") == "API System"
 
 
 class TestMultiTurnGrillLoop:
@@ -172,26 +153,21 @@ class TestMultiTurnGrillLoop:
         assert turn1.status == "in_refinement"
         assert turn1.updated_state["phase"] == "grilling"
 
-    def test_answers_fold_into_brief_and_complete(self):
+    def test_answers_fold_into_brief_and_reach_awaiting_approval(self):
         module = _make_module()
         with patch.object(module, "grill_round", return_value=_grill_incomplete()):
             turn1 = module.handle("/diagram a thing with some boxes", {})
 
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="API -> Backend"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg/>"
-                    turn2 = module.handle(
-                        "3 components: API Gateway, Backend, Database. Flows left to right.",
-                        turn1.updated_state,
-                    )
+            turn2 = module.handle(
+                "3 components: API Gateway, Backend, Database. Flows left to right.",
+                turn1.updated_state,
+            )
 
-        assert turn2.status == "completed"
-        assert "d2" in turn2.artifacts
-        assert "svg" in turn2.artifacts
+        assert turn2.status == "awaiting_approval"
 
-    def test_full_state_machine_transitions(self):
-        """init → in_refinement (grilling) → completed: all three state transitions."""
+    def test_full_state_machine_transitions(self, tmp_path: Path):
+        """init → in_refinement → awaiting_approval → completed: all four state transitions."""
         module = _make_module()
 
         # Transition 1: init → grilling
@@ -200,16 +176,23 @@ class TestMultiTurnGrillLoop:
         assert t1.status == "in_refinement"
         assert t1.updated_state["phase"] == "grilling"
 
-        # Transition 2: grilling → completed (answers complete the brief)
+        # Transition 2: grilling → awaiting_approval
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="API -> Backend -> Database"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg bytes/>"
-                    t2 = module.handle("API Gateway, Backend, Database left to right", t1.updated_state)
+            t2 = module.handle("API Gateway, Backend, Database left to right", t1.updated_state)
+        assert t2.status == "awaiting_approval"
+        assert t2.updated_state["phase"] == "awaiting_approval"
 
-        assert t2.status == "completed"
-        assert t2.artifacts.get("d2") == "API -> Backend -> Database"
-        assert t2.artifacts.get("svg") == b"<svg bytes/>"
+        # Transition 3: awaiting_approval → completed (user approves)
+        with patch.object(module, "_generate_d2_from_brief", return_value="API -> Backend -> Database"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_cls.return_value.generate_svg.return_value = b"<svg bytes/>"
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram.return_value = tmp_path / "diagrams" / "x_123"
+                    t3 = module.handle("yes", t2.updated_state)
+
+        assert t3.status == "completed"
+        assert t3.artifacts.get("d2") == "API -> Backend -> Database"
+        assert t3.artifacts.get("svg") == b"<svg bytes/>"
 
     def test_grill_turn_passes_original_description_as_context(self):
         captured: dict = {}
@@ -223,38 +206,194 @@ class TestMultiTurnGrillLoop:
             return _grill_complete()
 
         with patch.object(module, "grill_round", side_effect=capture_grill):
-            with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg/>"
-                    module.handle("bronze, silver, gold layers", t1.updated_state)
+            module.handle("bronze, silver, gold layers", t1.updated_state)
 
         assert "medallion architecture" in captured["description"]
         assert "bronze, silver, gold layers" in captured["description"]
 
-    def test_svg_bytes_propagate_to_final_response(self):
+    def test_svg_bytes_propagate_to_final_response(self, tmp_path: Path):
         module = _make_module()
         with patch.object(module, "grill_round", return_value=_grill_incomplete()):
             t1 = module.handle("/diagram a system", {})
 
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="X -> Y"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_cls.return_value.generate_svg.return_value = b"<svg>real svg</svg>"
-                    t2 = module.handle("answer", t1.updated_state)
+            t2 = module.handle("answer", t1.updated_state)
 
-        assert t2.artifacts["svg"] == b"<svg>real svg</svg>"
+        with patch.object(module, "_generate_d2_from_brief", return_value="X -> Y"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_cls.return_value.generate_svg.return_value = b"<svg>real svg</svg>"
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram.return_value = tmp_path / "diagrams" / "x_123"
+                    t3 = module.handle("yes", t2.updated_state)
+
+        assert t3.artifacts["svg"] == b"<svg>real svg</svg>"
+
+
+class TestApprovalGate:
+    """Approval gate: awaiting_approval phase routing."""
+
+    _APPROVAL_INPUTS = ["yes", "approved", "looks good", "lgtm", "ship it"]
+    _REVISION_INPUTS = [
+        "please change the layout to vertical",
+        "add a load balancer",
+        "no thanks",
+        "can you make it horizontal",
+    ]
+
+    @pytest.mark.parametrize("phrase", _APPROVAL_INPUTS)
+    def test_approval_phrase_triggers_generation(self, phrase: str, tmp_path: Path):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_cls.return_value.generate_svg.return_value = b"<svg/>"
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram.return_value = tmp_path / "diagrams" / "x_1"
+                    result = module.handle(phrase, state)
+        assert result.status == "completed"
+
+    @pytest.mark.parametrize("phrase", _APPROVAL_INPUTS)
+    def test_approval_is_case_insensitive(self, phrase: str, tmp_path: Path):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_cls.return_value.generate_svg.return_value = b"<svg/>"
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram.return_value = tmp_path / "diagrams" / "x_1"
+                    result = module.handle(phrase.upper(), state)
+        assert result.status == "completed"
+
+    @pytest.mark.parametrize("revision", _REVISION_INPUTS)
+    def test_non_approval_re_enters_grill_loop(self, revision: str):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        with patch.object(module, "grill_round", return_value=_grill_incomplete()):
+            result = module.handle(revision, state)
+        assert result.status == "in_refinement"
+
+    def test_revision_preserves_prior_brief(self):
+        module = _make_module()
+        prior_brief = _grill_complete().updated_brief
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": prior_brief,
+        }
+
+        captured: dict = {}
+
+        def capture_grill(description: str, partial_brief: dict) -> GrillRound:
+            captured["brief"] = partial_brief
+            return _grill_incomplete()
+
+        with patch.object(module, "grill_round", side_effect=capture_grill):
+            module.handle("please change the layout to vertical", state)
+
+        assert captured["brief"] == prior_brief
+
+    def test_revision_does_not_write_files(self, tmp_path: Path):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        with patch.object(module, "grill_round", return_value=_grill_incomplete()):
+            module.handle("please change the layout to vertical", state)
+
+        diagrams_dir = tmp_path / "diagrams"
+        assert not diagrams_dir.exists()
+
+    def test_happy_path_persists_trio(self, tmp_path: Path):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        persist_mock = MagicMock(return_value=tmp_path / "diagrams" / "API_System_123")
+        with patch.object(module, "_generate_d2_from_brief", return_value="API -> DB"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_cls.return_value.generate_svg.return_value = b"<svg/>"
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram = persist_mock
+                    result = module.handle("yes", state)
+
+        persist_mock.assert_called_once()
+        assert "persisted_path" in result.artifacts
+
+    def test_happy_path_response_contains_d2(self, tmp_path: Path):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        with patch.object(module, "_generate_d2_from_brief", return_value="API -> Backend"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_cls.return_value.generate_svg.return_value = b"<svg/>"
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram.return_value = tmp_path / "diagrams" / "x"
+                    result = module.handle("yes", state)
+        assert "API -> Backend" in result.response_text
+
+    def test_d2_generation_failure_returns_error(self, tmp_path: Path):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        with patch.object(module, "_generate_d2_from_brief", return_value=None):
+            result = module.handle("yes", state)
+        assert result.status == "error"
+
+    def test_no_svg_when_engine_fails(self, tmp_path: Path):
+        module = _make_module()
+        state = {
+            "phase": "awaiting_approval",
+            "description": "API system",
+            "brief": _grill_complete().updated_brief,
+        }
+        with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_cls.return_value.generate_svg.return_value = None
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram.return_value = tmp_path / "diagrams" / "x"
+                    result = module.handle("yes", state)
+        assert "svg" not in result.artifacts
 
 
 class TestSketchFlagForwarding:
-    def test_sketch_true_forwarded_to_engine(self):
+    def test_sketch_true_forwarded_to_engine(self, tmp_path: Path):
         module = _make_module()
+
+        # First: grill completes → awaiting_approval
         with patch.object(module, "grill_round", return_value=_grill_complete()):
-            with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
-                with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
-                    mock_engine = MagicMock()
-                    mock_engine.generate_svg.return_value = b"<svg/>"
-                    mock_cls.return_value = mock_engine
-                    module.handle("/diagram a test diagram", {})
+            approval_state = module.handle("/diagram a test diagram", {}).updated_state
+
+        # Then: approve → generate
+        with patch.object(module, "_generate_d2_from_brief", return_value="A -> B"):
+            with patch("src.agents.diagram_studio.DiagramEngine") as mock_cls:
+                mock_engine = MagicMock()
+                mock_engine.generate_svg.return_value = b"<svg/>"
+                mock_cls.return_value = mock_engine
+                with patch("src.agents.diagram_studio.ArchitecturePersister") as mock_persister:
+                    mock_persister.return_value.persist_diagram.return_value = tmp_path / "diagrams" / "x"
+                    module.handle("yes", approval_state)
 
         mock_engine.generate_svg.assert_called_once()
         _, kwargs = mock_engine.generate_svg.call_args

--- a/tests/utils/test_m_persist_design.py
+++ b/tests/utils/test_m_persist_design.py
@@ -1,0 +1,96 @@
+from pathlib import Path
+
+import pytest
+
+from src.agents.diagram_studio import ComponentSpec, DiagramBrief, DiagramStyle, RelationshipSpec
+from src.utils.m_persist_design import ArchitecturePersister
+
+
+def _make_brief() -> DiagramBrief:
+    return DiagramBrief(
+        subject="Test Diagram",
+        components=[
+            ComponentSpec(name="API", shape="rectangle", group=None),
+            ComponentSpec(name="DB", shape="cylinder", group=None),
+        ],
+        relationships=[
+            RelationshipSpec(from_component="API", to_component="DB", label="queries"),
+        ],
+        layout_direction="right",
+        style=DiagramStyle(sketch=True),
+    )
+
+
+class TestPersistDiagram:
+    def test_all_three_files_exist(self, tmp_path: Path) -> None:
+        persister = ArchitecturePersister(save_path=str(tmp_path))
+        diagram_dir = persister.persist_diagram(
+            name="test_diagram",
+            brief=_make_brief(),
+            d2_source="API -> DB: queries",
+            svg_bytes=b"<svg><text>test</text></svg>",
+        )
+
+        assert (diagram_dir / "brief.md").exists()
+        assert (diagram_dir / "source.d2").exists()
+        assert (diagram_dir / "render.svg").exists()
+
+    def test_directory_is_under_diagrams_subdir(self, tmp_path: Path) -> None:
+        persister = ArchitecturePersister(save_path=str(tmp_path))
+        diagram_dir = persister.persist_diagram(
+            name="my_diagram",
+            brief=_make_brief(),
+            d2_source="A -> B",
+            svg_bytes=b"<svg/>",
+        )
+
+        assert diagram_dir.parent == tmp_path / "diagrams"
+
+    def test_brief_md_contains_subject(self, tmp_path: Path) -> None:
+        persister = ArchitecturePersister(save_path=str(tmp_path))
+        diagram_dir = persister.persist_diagram(
+            name="subject_check",
+            brief=_make_brief(),
+            d2_source="A -> B",
+            svg_bytes=b"<svg/>",
+        )
+
+        content = (diagram_dir / "brief.md").read_text(encoding="utf-8")
+        assert "Test Diagram" in content
+
+    def test_source_d2_contains_code(self, tmp_path: Path) -> None:
+        persister = ArchitecturePersister(save_path=str(tmp_path))
+        d2 = "API -> DB: queries"
+        diagram_dir = persister.persist_diagram(
+            name="d2_check",
+            brief=_make_brief(),
+            d2_source=d2,
+            svg_bytes=b"<svg/>",
+        )
+
+        assert (diagram_dir / "source.d2").read_text(encoding="utf-8") == d2
+
+    def test_render_svg_contains_bytes(self, tmp_path: Path) -> None:
+        persister = ArchitecturePersister(save_path=str(tmp_path))
+        svg = b"<svg><rect/></svg>"
+        diagram_dir = persister.persist_diagram(
+            name="svg_check",
+            brief=_make_brief(),
+            d2_source="A -> B",
+            svg_bytes=svg,
+        )
+
+        assert (diagram_dir / "render.svg").read_bytes() == svg
+
+    def test_persistence_failure_is_logged_and_reraised(self, tmp_path: Path) -> None:
+        from unittest.mock import patch
+
+        persister = ArchitecturePersister(save_path=str(tmp_path))
+        with patch("pathlib.Path.write_text", side_effect=OSError("disk full")):
+            with pytest.raises(OSError):
+                persister.persist_diagram(
+                    name="fail_test",
+                    brief=_make_brief(),
+                    d2_source="A -> B",
+                    svg_bytes=b"<svg/>",
+                )


### PR DESCRIPTION
## Summary
Automated implementation for issue #40 by Claude Code agent.

## Validation
- `uv run pytest` — ✅ passed (verified by orchestrator)

## Linked Issue
Closes #40
