### PR TITLE
feat(#41): `/help` and `/exit` meta-commands for the dispatcher

### DIFF
--- a/src/agents/workflow_dispatcher.py
+++ b/src/agents/workflow_dispatcher.py
@@ -27,24 +27,24 @@ class WorkflowDispatcher:
         command = user_input.split()[0].lower()
 
         if command == "/help":
-            return self._help(session_state)
+            return self._handle_help(session_state)
         if command == "/exit":
-            return self._exit(session_state)
+            return self._clear_active_module(session_state)
         if command in self._modules:
             return self._invoke_module(command, user_input, session_state)
         if command.startswith("/"):
-            return self._unknown_command(command, session_state)
+            return self._handle_unknown_command(command, session_state)
 
         active = session_state.get("active_module")
         if active and active in self._modules:
             return self._invoke_module(active, user_input, session_state)
         return DispatchResult(
-            response_text=self._help_text(),
+            response_text=self._build_help_table(),
             updated_state=session_state,
             status="unknown_command",
         )
 
-    def _help_text(self) -> str:
+    def _build_help_table(self) -> str:
         rows = ["| Slash Command | Module | Description |", "|---|---|---|"]
         for cmd, module in self._modules.items():
             name = getattr(module, "name", cmd)
@@ -52,24 +52,25 @@ class WorkflowDispatcher:
             rows.append(f"| `{cmd}` | {name} | {desc} |")
         return "\n".join(rows)
 
-    def _help(self, session_state: dict) -> DispatchResult:
+    def _handle_help(self, session_state: dict) -> DispatchResult:
         return DispatchResult(
-            response_text=self._help_text(),
+            response_text=self._build_help_table(),
             updated_state=session_state,
             status="completed",
         )
 
-    def _exit(self, session_state: dict) -> DispatchResult:
+    def _clear_active_module(self, session_state: dict) -> DispatchResult:
         updated = dict(session_state)
         active = updated.pop("active_module", None)
         if active and "module_state" in updated:
+            updated["module_state"] = dict(updated["module_state"])
             updated["module_state"].pop(active, None)
         msg = "Session cleared. Type `/help` to see available commands." if active else "No active module to exit."
         return DispatchResult(response_text=msg, updated_state=updated, status="completed")
 
-    def _unknown_command(self, command: str, session_state: dict) -> DispatchResult:
+    def _handle_unknown_command(self, command: str, session_state: dict) -> DispatchResult:
         return DispatchResult(
-            response_text=f"Unknown command: `{command}`.\n\n{self._help_text()}",
+            response_text=f"Unknown command: `{command}`.\n\n{self._build_help_table()}",
             updated_state=session_state,
             status="unknown_command",
         )

--- a/src/agents/workflow_dispatcher.py
+++ b/src/agents/workflow_dispatcher.py
@@ -26,18 +26,50 @@ class WorkflowDispatcher:
     def dispatch(self, user_input: str, session_state: dict) -> DispatchResult:
         command = user_input.split()[0].lower()
 
-        if command not in self._modules:
-            return self._route_to_active_or_unknown(command, user_input, session_state)
+        if command == "/help":
+            return self._help(session_state)
+        if command == "/exit":
+            return self._exit(session_state)
+        if command in self._modules:
+            return self._invoke_module(command, user_input, session_state)
+        if command.startswith("/"):
+            return self._unknown_command(command, session_state)
 
-        return self._invoke_module(command, user_input, session_state)
-
-    def _route_to_active_or_unknown(self, command: str, user_input: str, session_state: dict) -> DispatchResult:
         active = session_state.get("active_module")
         if active and active in self._modules:
             return self._invoke_module(active, user_input, session_state)
-        known = ", ".join(self._modules.keys())
         return DispatchResult(
-            response_text=f"Unknown command `{command}`. Available: {known}.",
+            response_text=self._help_text(),
+            updated_state=session_state,
+            status="unknown_command",
+        )
+
+    def _help_text(self) -> str:
+        rows = ["| Slash Command | Module | Description |", "|---|---|---|"]
+        for cmd, module in self._modules.items():
+            name = getattr(module, "name", cmd)
+            desc = getattr(module, "description", "")
+            rows.append(f"| `{cmd}` | {name} | {desc} |")
+        return "\n".join(rows)
+
+    def _help(self, session_state: dict) -> DispatchResult:
+        return DispatchResult(
+            response_text=self._help_text(),
+            updated_state=session_state,
+            status="completed",
+        )
+
+    def _exit(self, session_state: dict) -> DispatchResult:
+        updated = dict(session_state)
+        active = updated.pop("active_module", None)
+        if active and "module_state" in updated:
+            updated["module_state"].pop(active, None)
+        msg = "Session cleared. Type `/help` to see available commands." if active else "No active module to exit."
+        return DispatchResult(response_text=msg, updated_state=updated, status="completed")
+
+    def _unknown_command(self, command: str, session_state: dict) -> DispatchResult:
+        return DispatchResult(
+            response_text=f"Unknown command: `{command}`.\n\n{self._help_text()}",
             updated_state=session_state,
             status="unknown_command",
         )

--- a/src/ui/app.py
+++ b/src/ui/app.py
@@ -91,7 +91,7 @@ st.set_page_config(page_title="Azure Architecture Agent", layout="wide")
 st.title("Architecture Agent 🛡️")
 st.markdown("### Technical Design Authority Agent")
 
-WELCOME_MESSAGE = "Welcome. Please describe the architecture you want to build."
+WELCOME_MESSAGE = "Welcome. Type `/help` to see available commands, or describe the architecture you want to build."
 
 # Session state initialization
 if "maf_state" not in st.session_state:

--- a/tests/agents/test_workflow_dispatcher.py
+++ b/tests/agents/test_workflow_dispatcher.py
@@ -28,12 +28,6 @@ class TestCommandParsing:
         result = d.dispatch("/bogus", {})
         assert "/diagram" in result.response_text
 
-    def test_unknown_command_includes_prefix(self):
-        d = _make_dispatcher()
-        result = d.dispatch("/dgram", {})
-        assert "Unknown command" in result.response_text
-        assert "/dgram" in result.response_text
-
     def test_known_command_routes_to_module(self):
         d = _make_dispatcher()
         d._modules["/diagram"].handle = MagicMock(return_value=_mock_module_response("D2 output"))

--- a/tests/agents/test_workflow_dispatcher.py
+++ b/tests/agents/test_workflow_dispatcher.py
@@ -28,6 +28,12 @@ class TestCommandParsing:
         result = d.dispatch("/bogus", {})
         assert "/diagram" in result.response_text
 
+    def test_unknown_command_includes_prefix(self):
+        d = _make_dispatcher()
+        result = d.dispatch("/dgram", {})
+        assert "Unknown command" in result.response_text
+        assert "/dgram" in result.response_text
+
     def test_known_command_routes_to_module(self):
         d = _make_dispatcher()
         d._modules["/diagram"].handle = MagicMock(return_value=_mock_module_response("D2 output"))
@@ -100,6 +106,34 @@ class TestMultiTurnActiveModuleRouting:
         result = d.dispatch("my answer", prior)
         assert result.updated_state["module_state"]["/diagram"]["phase"] == "grilling"
         assert result.updated_state["module_state"]["/diagram"]["step"] == 2
+
+
+class TestMetaCommands:
+    def test_help_returns_markdown_table_with_all_modules(self):
+        d = _make_dispatcher()
+        result = d.dispatch("/help", {})
+        assert result.status == "completed"
+        assert "Slash Command" in result.response_text
+        assert "/diagram" in result.response_text
+
+    def test_exit_clears_active_module_and_module_state(self):
+        d = _make_dispatcher()
+        prior = {
+            "active_module": "/diagram",
+            "module_state": {"/diagram": {"phase": "grilling"}},
+        }
+        result = d.dispatch("/exit", prior)
+        assert result.status == "completed"
+        assert "active_module" not in result.updated_state
+        assert "/diagram" not in result.updated_state.get("module_state", {})
+
+    def test_unknown_slash_command_prepends_unknown_prefix_and_shows_help(self):
+        d = _make_dispatcher()
+        result = d.dispatch("/dgram", {})
+        assert result.status == "unknown_command"
+        assert "Unknown command" in result.response_text
+        assert "/dgram" in result.response_text
+        assert "/diagram" in result.response_text
 
 
 class TestExceptionIsolation:


### PR DESCRIPTION
## Summary
Automated implementation for issue #41 by Claude Code agent.

## Validation
- `uv run pytest` — ✅ passed (verified by orchestrator)

## Linked Issue
Closes #41
