### PR TITLE
feat(#68): Add OIDC federated credential for CI auth and retire SP-secret remnants

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,11 +22,16 @@ AZURE_AAIF_PROJECT_ENDPOINT=
 
 # --- Azure Authentication ---
 # AZURE_AUTH_MODE controls which credential flow is used.
-#   cli            — DefaultAzureCredential prefers `az login` (default for local dev)
-#   sp             — Force Service Principal via the three vars below
+#   cli (default)  — DefaultAzureCredential prefers `az login` for local dev;
+#                    the cloud container uses the UAMI; CI uses OIDC federation.
+#   sp             — MANUAL-ONLY LOCAL PATH. Forces Service Principal auth via
+#                    AZURE_CLIENT_ID + AZURE_TENANT_ID + AZURE_CLIENT_SECRET.
+#                    Use only when testing SP auth locally with a manually
+#                    obtained secret — CI and cloud never set this value.
 #
-# Run `cd infra && terraform apply` to provision sp-helloarch-dev,
-# then copy the outputs into the vars below.
+# The AZURE_CLIENT_ID and AZURE_TENANT_ID below are shared across auth modes
+# (UAMI client ID in the cloud, SP client ID locally). AZURE_CLIENT_SECRET is
+# only read when AZURE_AUTH_MODE=sp; leave it empty for normal `cli` usage.
 AZURE_AUTH_MODE=cli
 AZURE_CLIENT_ID=
 AZURE_TENANT_ID=

--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ To run this application locally, you must satisfy the following environment and 
 5.  **Environment Variables**: Create a `.env` file in the project root with:
     - `AZURE_AAIF_PROJECT_ENDPOINT`: The endpoint for your AI Foundry project (e.g., `https://<REGION>.api.azureml.ms`).
     - (Optional) `SECOND_BRAIN_PATH`: Absolute path to your local `my_second_brain` repository (e.g., `/home/user/my_second_brain`). When set, `CapabilityRepository` reads from `$SECOND_BRAIN_PATH/capabilities/` and approved designs are written to `$SECOND_BRAIN_PATH/architecture/designs/approved/`. If unset, the engine falls back to local project directories (safe for CI).
-    - (Optional) `AZURE_AUTH_MODE`: Set to `cli` (default) for `az login` or `sp` for Service Principal.
-    - (Optional) `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`: Required if `AZURE_AUTH_MODE=sp`.
+    - (Optional) `AZURE_AUTH_MODE`: Set to `cli` (default) for `az login`. The `sp` value is a **manual-only local path** — it forces Service Principal credential lookup via `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_CLIENT_SECRET`; it is never used by CI (which authenticates via OIDC federation) or the cloud runtime (which uses the UAMI).
+    - (Optional) `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET`: Only required when `AZURE_AUTH_MODE=sp` for manual local SP testing. Leave empty for normal `az login` usage.
 6.  **Model Deployments**: Ensure the following models are deployed in your AI Foundry project with names matching `config.py`:
     - `gpt-5-mini` (Intake Reviewer)
     - `DeepSeek-V3.1` (Architecture Composer)
@@ -139,7 +139,7 @@ cm = ClientManager()  # uses DefaultAzureCredential (az login or service princip
 orchestrator = AgenticOrchestrator(client_manager=cm)
 ```
 
-Set `AZURE_AAIF_PROJECT_ENDPOINT` and optionally `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_CLIENT_SECRET` in your `.env` or environment before running.
+Set `AZURE_AAIF_PROJECT_ENDPOINT` in your `.env` before running. `AZURE_CLIENT_ID` and `AZURE_TENANT_ID` are optional for local dev (used by the UAMI in the cloud). `AZURE_CLIENT_SECRET` is only needed when using the manual-only `AZURE_AUTH_MODE=sp` local path — never set in CI or cloud environments.
 
 ## Code Validation
 ```powershell

--- a/docs/adr/ADR-015-remote-state-platform-rg.md
+++ b/docs/adr/ADR-015-remote-state-platform-rg.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Accepted — OIDC fast-follow completed in issue #68
 
 ## Context and Problem Statement
 
@@ -29,7 +29,7 @@ The platform RG is long-lived and project-agnostic: one state account backs ever
 **Secrets stance: harden the backend; do not introduce Key Vault for this concern.** The load-bearing insight is that *anything Terraform manages lands in state in plaintext* — so Key Vault as a write destination does not remove a Terraform-generated secret from state. Key Vault is therefore not a solution to secret-in-state and is deferred until a genuine runtime secret (one that managed identity cannot cover) exists, consistent with [ADR-008](ADR-008-secrets-management.md) designating Key Vault as the production-corporate store.
 
 Instead, in priority order:
-1. **Eliminate secrets** — the cloud path is already secretless via managed identity (UAMI → ACR + Foundry); local dev uses `az login` + `DefaultAzureCredential`. Removing the optional Service Principal password (and using OIDC workload-identity federation for CI) is tracked as a fast-follow.
+1. **Eliminate secrets** — the cloud path is already secretless via managed identity (UAMI → ACR + Foundry); local dev uses `az login` + `DefaultAzureCredential`. The optional Service Principal password has been removed; CI authenticates via OIDC workload-identity federation (completed in issue #68, superseding the SP-password portion of ADR-013). `AZURE_AUTH_MODE=sp` is retained solely as a **manual-only local path** — `AZURE_CLIENT_SECRET` is never stored in Terraform state or injected into CI or cloud environments.
 2. **Harden the state backend** (this ADR) — RBAC/Entra-only (`--allow-shared-key-access false`, `use_azuread_auth = true`), no public blob access, blob versioning + soft-delete for recovery. Encryption at rest is on by default. This protects the residual secrets that always leak into state.
 
 ### Positive Consequences
@@ -43,7 +43,7 @@ Instead, in priority order:
 
 - A one-time manual bootstrap (`az` commands in README) is required before `terraform init -migrate-state`, since the backend cannot provision the account it depends on (chicken-and-egg).
 - The platform RG/account is now a shared dependency whose deletion would affect every project's state — it must be treated as protected infrastructure.
-- Secrets still reside in state until the SP-password elimination fast-follow lands; backend hardening is the interim mitigation.
+- ~~Secrets still reside in state until the SP-password elimination fast-follow lands; backend hardening is the interim mitigation.~~ Resolved in issue #68: the SP password was removed and CI now uses OIDC federation; no extractable secret lands in state.
 
 ## Pros and Cons of the Options
 

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -77,8 +77,34 @@ resource "azuread_service_principal" "helloarch" {
 }
 
 # No client secret is provisioned: the app uses DefaultAzureCredential (az login
-# locally, UAMI in the cloud). A credential is attached later as an OIDC federated
-# identity for CI (ADR-015 fast-follow), never a long-lived secret in state.
+# locally, UAMI in the cloud). CI authenticates via the OIDC federated credential
+# below — a short-lived token exchange, never a long-lived secret in state (ADR-015).
+
+# --- OIDC federated credential for CI (GitHub Actions) ---
+# The GitHub Actions OIDC token is exchanged for an Azure access token without any
+# stored secret. Subject targets the master branch; tighten to an environment-scoped
+# subject if GitHub environment protection is adopted later.
+resource "azuread_application_federated_identity_credential" "ci_oidc" {
+  application_id = azuread_application.helloarch.id
+  display_name   = "github-ci-master"
+  audiences      = ["api://AzureADTokenExchange"]
+  issuer         = "https://token.actions.githubusercontent.com"
+  subject        = "repo:ysuurme/azure_hello_world:ref:refs/heads/master"
+}
+
+# --- RBAC: CI principal → tfstate container (state read + blob-lease locking) ---
+# Storage Blob Data Contributor (write) is required because terraform acquires a
+# blob lease on the state file to prevent concurrent apply corruption.
+data "azurerm_storage_account" "platform" {
+  name                = "stplatformydev"
+  resource_group_name = "rg-platformy-dev"
+}
+
+resource "azurerm_role_assignment" "sp_tfstate_blob_contributor" {
+  scope                = "${data.azurerm_storage_account.platform.id}/blobServices/default/containers/tfstate"
+  role_definition_name = "Storage Blob Data Contributor"
+  principal_id         = azuread_service_principal.helloarch.object_id
+}
 
 # --- RBAC: SP → Foundry account (project ops + inference) ---
 resource "azurerm_role_assignment" "sp_ai_developer" {

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -82,14 +82,15 @@ resource "azuread_service_principal" "helloarch" {
 
 # --- OIDC federated credential for CI (GitHub Actions) ---
 # The GitHub Actions OIDC token is exchanged for an Azure access token without any
-# stored secret. Subject targets the master branch; tighten to an environment-scoped
-# subject if GitHub environment protection is adopted later.
+# stored secret. Subject targets pull_request events because infra-plan.yml triggers
+# on pull_request (not push). GitHub issues sub=...pull_request for that event type;
+# ref:refs/heads/master would only match push-to-master triggers.
 resource "azuread_application_federated_identity_credential" "ci_oidc" {
   application_id = azuread_application.helloarch.id
-  display_name   = "github-ci-master"
+  display_name   = "github-ci-pr"
   audiences      = ["api://AzureADTokenExchange"]
   issuer         = "https://token.actions.githubusercontent.com"
-  subject        = "repo:ysuurme/azure_hello_world:ref:refs/heads/master"
+  subject        = "repo:ysuurme/azure_hello_world:pull_request"
 }
 
 # --- RBAC: CI principal → tfstate container (state read + blob-lease locking) ---

--- a/src/config.py
+++ b/src/config.py
@@ -58,10 +58,18 @@ settings = _Settings()
 # Controls whether the app should prefer interactive Azure CLI login (default)
 # or explicitly use Service Principal credentials from environment variables.
 #
-# Set `AZURE_AUTH_MODE=sp` or `AZURE_AUTH_MODE=service_principal` to force
-# service-principal usage via `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and
-# `AZURE_CLIENT_SECRET`. Default is `cli` which allows `az login` to be used
-# when available; empty SP placeholders in `.env` will be ignored so CLI can
-# continue to work locally.
+# SUPPORTED VALUES:
+#   cli (default) — DefaultAzureCredential prefers `az login`; the cloud runtime
+#                   uses the container's User-Assigned Managed Identity (UAMI);
+#                   CI uses the OIDC federated credential (ADR-015, issue #68).
+#   sp            — MANUAL-ONLY LOCAL PATH. Forces Service Principal credential
+#                   lookup via AZURE_CLIENT_ID, AZURE_TENANT_ID, and
+#                   AZURE_CLIENT_SECRET. Intended exclusively for local testing
+#                   with a manually obtained SP secret — never used by CI or the
+#                   cloud runtime, and AZURE_CLIENT_SECRET is never stored in
+#                   Terraform state or injected into the container environment.
+#
+# Empty SP placeholder values in `.env` are silently removed so the `cli` flow
+# can continue to work alongside a partially-populated .env file.
 AZURE_AUTH_MODE = os.getenv("AZURE_AUTH_MODE", "cli").lower()
 USE_AZURE_SERVICE_PRINCIPAL = AZURE_AUTH_MODE in ("sp", "service_principal", "client_secret")

--- a/tests/infra/test_terraform.py
+++ b/tests/infra/test_terraform.py
@@ -135,10 +135,29 @@ def test_oidc_issuer_github_actions() -> None:
     )
 
 
-def test_oidc_subject_master_branch() -> None:
+def test_oidc_subject_pull_request() -> None:
+    """OIDC subject must match the pull_request trigger used by infra-plan.yml.
+
+    GitHub issues sub=repo:...:pull_request for pull_request events and
+    sub=repo:...:ref:refs/heads/<branch> for push events — they are different
+    claims. Using the wrong subject causes Azure AD to reject the token exchange.
+    """
     content = MAIN_TF.read_text()
-    assert "repo:ysuurme/azure_hello_world:ref:refs/heads/master" in content, (
-        "OIDC subject must target the master branch of the repository"
+    assert "repo:ysuurme/azure_hello_world:pull_request" in content, (
+        "OIDC subject must be pull_request to match the infra-plan.yml pull_request trigger"
+    )
+
+
+def test_oidc_subject_consistent_with_workflow_trigger() -> None:
+    """Cross-validate: the registered OIDC subject must be compatible with the
+    event type that triggers infra-plan.yml, otherwise Azure AD will reject the
+    token exchange and every plan run will fail with a 401."""
+    workflow = Path(__file__).parent.parent.parent / ".github" / "workflows" / "infra-plan.yml"
+    tf_content = MAIN_TF.read_text()
+    wf_content = workflow.read_text(encoding="utf-8")
+    assert "pull_request" in wf_content, "infra-plan.yml must trigger on pull_request"
+    assert "repo:ysuurme/azure_hello_world:pull_request" in tf_content, (
+        "OIDC subject in main.tf must be pull_request to match the pull_request workflow trigger"
     )
 
 

--- a/tests/infra/test_terraform.py
+++ b/tests/infra/test_terraform.py
@@ -117,6 +117,49 @@ def test_mistral_models_present() -> None:
         assert dep in content, f"model_deployments default must include {dep}"
 
 
+# --- OIDC federated credential -------------------------------------------
+
+
+def test_federated_identity_credential_defined() -> None:
+    """CI authenticates via OIDC federation, not a stored secret (ADR-015)."""
+    content = MAIN_TF.read_text()
+    assert "azuread_application_federated_identity_credential" in content, (
+        "OIDC federated credential must be defined on the application"
+    )
+
+
+def test_oidc_issuer_github_actions() -> None:
+    content = MAIN_TF.read_text()
+    assert "https://token.actions.githubusercontent.com" in content, (
+        "OIDC issuer must be the GitHub Actions token endpoint"
+    )
+
+
+def test_oidc_subject_master_branch() -> None:
+    content = MAIN_TF.read_text()
+    assert "repo:ysuurme/azure_hello_world:ref:refs/heads/master" in content, (
+        "OIDC subject must target the master branch of the repository"
+    )
+
+
+# --- CI principal: Storage Blob Data Contributor on tfstate --------------
+
+
+def test_sp_tfstate_blob_contributor_defined() -> None:
+    """CI principal needs write on tfstate for blob-lease locking during terraform apply."""
+    content = MAIN_TF.read_text()
+    assert '"Storage Blob Data Contributor"' in content, (
+        "CI principal must be granted Storage Blob Data Contributor on the tfstate container"
+    )
+
+
+def test_sp_tfstate_platform_storage_referenced() -> None:
+    content = MAIN_TF.read_text()
+    assert "stplatformydev" in content, (
+        "Storage Blob Data Contributor grant must reference the platform state account stplatformydev"
+    )
+
+
 # --- Service Principal & RBAC --------------------------------------------
 
 


### PR DESCRIPTION
## Summary
Automated implementation for issue #68 by Claude Code agent.

## Validation
- `uv run pytest` — ✅ passed (verified by orchestrator)

## Linked Issue
Closes #68
