### PR TITLE
feat(#75): Default the D2 layout engine to ELK with direction heuristics

### DIFF
--- a/docs/adr/ADR-011-diagram-studio-sketch.md
+++ b/docs/adr/ADR-011-diagram-studio-sketch.md
@@ -6,7 +6,7 @@ description: Diagram Studio module — first capability under ADR-010; refines a
 # ADR-011: Diagram Studio Module with Native D2 Sketch Rendering
 
 ## Status
-Accepted
+Accepted — amended (ELK layout engine, 2026-05-25)
 
 ## applies_to
 application, agent
@@ -56,6 +56,35 @@ Chosen option: **Option A**, because (i) engine-level `--sketch` makes the style
 * `src/agents/architecture_composer.py` system prompt no longer references `theme: sketch` — sketch styling is no longer a composer concern.
 * Tests in `tests/agents/test_diagram_studio.py` cover: grill round produces questions with recommendations, brief approval gate works, generated D2 is non-empty, rendered SVG bytes are produced, brief/D2/SVG trio is persisted.
 * Revisit when (a) users repeatedly skip the grill and just want one-shot generation — signal that the `/diagram --quick` escape hatch should be promoted; or (b) the `DiagramBrief` schema has been forked for two other modules — signal that the mixin should be promoted to a full base class.
+
+## Amendment: ELK Layout Engine (2026-05-25)
+
+### Context
+
+The original decision enforced `--sketch` at the engine level but left the layout engine at the D2 default (`dagre`). Dagre is unmaintained and routes poorly through deep container nesting and ancestor→descendant edges, producing illegible blocks-in-blocks output. The bundled D2 binary ships ELK; ELK's orthogonal routing guarantees edges between nested children do not cut through unrelated parent containers.
+
+### Decision
+
+`DiagramStyle` gains a `layout_engine: str = "elk"` field. `DiagramEngine.generate_svg` appends `--layout <style.layout_engine>` to the D2 CLI invocation alongside the existing `--sketch`/`--theme`/`--pad` flags. The engine is overridable via `DiagramStyle(layout_engine="dagre")` when the caller has a specific reason.
+
+`_DEFAULT_CONVENTIONS` is extended with direction-selection heuristics:
+- `direction: right` — temporal/streaming/pipeline flows (data moves left-to-right through stages)
+- `direction: down` — multi-tier infrastructure stacks (client → gateway → service → data tiers)
+
+### In-container verification
+
+The smoke test suite (`@pytest.mark.integration`) calls the real D2/ELK binary with a nested-container diagram that exercises ancestor→descendant edges (blocks-in-blocks). Run it inside the container:
+
+```bash
+# Inside a running container:
+uv run pytest -m integration -v
+
+# One-shot verification without the test suite:
+echo 'direction: down\nouter: { a: "A"; a.class: service\n  b: "B"; b.class: datastore\n}\nouter.a -> outer.b: write' \
+  | d2 --layout elk - /tmp/test.svg && echo "ELK OK: $(wc -c < /tmp/test.svg) bytes"
+```
+
+Verified locally (Windows, D2 v0.7.1 with bundled ELK): nested-container D2 with ancestor→descendant edges renders to SVG without routing errors.
 
 ## Pros and Cons of the Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,9 @@ dev = [
 
 [tool.pytest.ini_options]
 pythonpath = ["."]
+markers = [
+    "integration: smoke tests that invoke live binaries; require D2 to be installed (skip with -m 'not integration')",
+]
 
 [tool.ruff]
 target-version = "py310"

--- a/src/utils/m_diagram_engine.py
+++ b/src/utils/m_diagram_engine.py
@@ -43,7 +43,9 @@ class DiagramEngine:
                     args.append("--sketch")
                 if style.theme is not None:
                     args += ["--theme", str(style.theme)]
-                args += ["--pad", str(style.pad), input_file, output_file]
+                args += ["--pad", str(style.pad)]
+                args += ["--layout", style.layout_engine]
+                args += [input_file, output_file]
                 # Standard library boundary: invoke the static binary
                 subprocess.run(args, capture_output=True, text=True, check=True)
 

--- a/src/utils/m_diagram_style.py
+++ b/src/utils/m_diagram_style.py
@@ -41,7 +41,10 @@ _DEFAULT_CONVENTIONS = (
     "  }\n"
     "Conventions: group related components inside containers (blocks-in-blocks); use a `boundary`-classed "
     "container for trust/network zones; reference nested shapes by full path in edges; label every edge "
-    "with what flows; solid arrows for sync, dashed (`style.stroke-dash: 4`) for async/events."
+    "with what flows; solid arrows for sync, dashed (`style.stroke-dash: 4`) for async/events.\n"
+    "Direction selection: use `direction: right` for temporal/streaming/pipeline flows (data moves left to "
+    "right through stages); use `direction: down` for multi-tier infrastructure stacks (client → gateway → "
+    "service → data tiers layered top to bottom)."
 )
 
 
@@ -51,6 +54,7 @@ class DiagramStyle:
     sketch: bool = True
     theme: int | None = 0  # D2 theme id; 0 = neutral so the explicit palette dominates
     pad: int = 20
+    layout_engine: str = "elk"
     d2_preamble: str = _DEFAULT_PREAMBLE
     conventions: str = _DEFAULT_CONVENTIONS
 

--- a/tests/utils/test_m_diagram_engine.py
+++ b/tests/utils/test_m_diagram_engine.py
@@ -1,7 +1,35 @@
+import shutil
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 from src.utils.m_diagram_engine import DiagramEngine
 from src.utils.m_diagram_style import DiagramStyle
+
+_D2_AVAILABLE = shutil.which("d2") is not None
+
+_NESTED_CONTAINER_D2 = """\
+direction: down
+services: "Services" {
+  api: "API Gateway"
+  api.class: service
+  workers: "Workers" {
+    worker_a: "Worker A"
+    worker_a.class: service
+    worker_b: "Worker B"
+    worker_b.class: service
+  }
+}
+storage: "Storage" {
+  db: "Database"
+  db.class: datastore
+  cache: "Cache"
+  cache.class: datastore
+}
+services.api -> services.workers.worker_a: dispatch
+services.workers.worker_a -> storage.db: write
+services.workers.worker_b -> storage.cache: read
+"""
 
 
 def _capture_run(captured: dict):
@@ -77,3 +105,26 @@ class TestStyleApplication:
             DiagramEngine().generate_svg("foo -> bar")
 
         assert captured["d2"] == "foo -> bar"
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _D2_AVAILABLE, reason="D2 binary not installed; run inside the container or install D2 locally")
+class TestELKSmoke:
+    """Calls the real D2 binary to confirm ELK renders nested-container diagrams without error.
+
+    Run locally:  uv run pytest -m integration
+    Run in-container: docker exec <container> uv run pytest -m integration
+    """
+
+    def test_elk_renders_nested_container_to_svg(self):
+        """ELK must produce non-empty SVG from a blocks-in-blocks diagram with ancestor→descendant edges."""
+        svg = DiagramEngine().generate_svg(_NESTED_CONTAINER_D2, style=DiagramStyle(layout_engine="elk"))
+        assert svg is not None, "generate_svg returned None — D2/ELK binary error"
+        assert len(svg) > 0
+        assert b"<svg" in svg
+
+    def test_elk_is_default_in_generated_output(self):
+        """DiagramStyle default (elk) must produce valid SVG without caller specifying layout_engine."""
+        svg = DiagramEngine().generate_svg(_NESTED_CONTAINER_D2)
+        assert svg is not None, "generate_svg returned None with default DiagramStyle"
+        assert b"<svg" in svg

--- a/tests/utils/test_m_diagram_engine.py
+++ b/tests/utils/test_m_diagram_engine.py
@@ -43,6 +43,26 @@ class TestStyleApplication:
         assert cmd[cmd.index("--theme") + 1] == "5"
         assert cmd[cmd.index("--pad") + 1] == "33"
 
+    def test_layout_engine_default_is_elk(self):
+        captured: dict = {}
+        with patch("src.utils.m_diagram_engine.subprocess.run", side_effect=_capture_run(captured)):
+            DiagramEngine().generate_svg("A -> B")
+        cmd = captured["cmd"]
+        assert cmd[cmd.index("--layout") + 1] == "elk"
+
+    def test_layout_engine_sourced_from_style(self):
+        captured: dict = {}
+        with patch("src.utils.m_diagram_engine.subprocess.run", side_effect=_capture_run(captured)):
+            DiagramEngine().generate_svg("A -> B", style=DiagramStyle(layout_engine="dagre"))
+        cmd = captured["cmd"]
+        assert cmd[cmd.index("--layout") + 1] == "dagre"
+
+    def test_layout_flag_always_present_in_cli_call(self):
+        captured: dict = {}
+        with patch("src.utils.m_diagram_engine.subprocess.run", side_effect=_capture_run(captured)):
+            DiagramEngine().generate_svg("A -> B", style=DiagramStyle(sketch=False))
+        assert "--layout" in captured["cmd"]
+
     def test_renders_d2_as_is(self):
         captured: dict = {}
 


### PR DESCRIPTION
## Summary
Automated implementation for issue #75 by Claude Code agent.

## Validation
- `uv run pytest` — ✅ passed (verified by orchestrator)

## Linked Issue
Closes #75
